### PR TITLE
Use stardoc for generating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 This repository contains rules for Bazel that allow you to compile your SQL
 files into a Go package that can be used for type-safe database code.
 
-# I'm impatient, how do I use them?
+## Table of Contents
+1. [Setup](#setup)
+2. [Usage](#usage)
+3. [Documentation](#documentation)
+
 ## Setup
 The first thing you need to do is load the rules in your WORKSPACE file to make
 them available in your Bazel repository.
@@ -88,3 +92,10 @@ go_library(
     importpath = "example.com/owner/repo/database",
 )
 ```
+
+# Documentation
+Full details on the use of the sqlc_package rule can be found in the [rules
+documentation](docs/rules.md).
+
+The `SQLCRelease` bazel provider (for writers of further bazel rules) can be
+found in the [provider documentation](docs/providers.md).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,18 @@ sqlc_rules_dependencies()
 
 sqlc_register_toolchains()
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "io_bazel_stardoc",
+    remote = "https://github.com/bazelbuild/stardoc.git",
+    tag = "0.4.0",
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+
 # Download the Go rules.
 http_archive(
     name = "io_bazel_rules_go",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -12,37 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-filegroup(
-    name = "all_rules",
-    srcs = glob(["**/*.bzl"]),
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "all_files",
-    testonly = True,
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-
 bzl_library(
-    name = "release",
-    srcs = ["release.bzl"],
-    visibility = ["//sqlc:__subpackages__"],
+    name = "docs",
+    srcs = ["docs.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
-        "@plezentek_bazel_sqlc//sqlc/private:providers",
+        "//sqlc:def",
     ],
 )
 
-bzl_library(
-    name = "package",
-    srcs = [
-        "package.bzl",
+stardoc(
+    name = "sqlc_package-docs",
+    out = "rules.md",
+    input = "docs.bzl",
+    symbol_names = [
+        "sqlc_package",
     ],
-    visibility = ["//sqlc:__subpackages__"],
-    deps = [
-        "@plezentek_bazel_sqlc//sqlc/private:actions",
+    deps = [":docs"],
+)
+
+stardoc(
+    name = "sqlc_provder-docs",
+    out = "providers.md",
+    input = "docs.bzl",
+    symbol_names = [
+        "SQLCRelease",
     ],
+    deps = [":docs"],
 )

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -1,0 +1,5 @@
+load("//sqlc:def.bzl", _sqlc_package = "sqlc_package")
+load("//sqlc:def.bzl", _SQLCRelease = "SQLCRelease")
+
+sqlc_package = _sqlc_package
+SQLCRelease = _SQLCRelease

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,24 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a name="#SQLCRelease"></a>
+
+## SQLCRelease
+
+<pre>
+SQLCRelease(<a href="#SQLCRelease-goos">goos</a>, <a href="#SQLCRelease-goarch">goarch</a>, <a href="#SQLCRelease-root_file">root_file</a>, <a href="#SQLCRelease-sqlc">sqlc</a>, <a href="#SQLCRelease-version">version</a>)
+</pre>
+
+Contains information about the SQLC release used in the toolchain
+
+**FIELDS**
+
+
+| Name  | Description |
+| :-------------: | :-------------: |
+| goos |  The host OS the release was built for.    |
+| goarch |  The host architecture the release was built for.    |
+| root_file |  The file at the base of the toolchain context    |
+| sqlc |  The sqlc binary to execute    |
+| version |  The version of the sqlc binary used    |
+
+

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,42 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a name="#sqlc_package"></a>
+
+## sqlc_package
+
+<pre>
+sqlc_package(<a href="#sqlc_package-name">name</a>, <a href="#sqlc_package-emit_empty_slices">emit_empty_slices</a>, <a href="#sqlc_package-emit_exact_table_names">emit_exact_table_names</a>, <a href="#sqlc_package-emit_interface">emit_interface</a>, <a href="#sqlc_package-emit_json_tags">emit_json_tags</a>,
+             <a href="#sqlc_package-emit_prepared_queries">emit_prepared_queries</a>, <a href="#sqlc_package-engine">engine</a>, <a href="#sqlc_package-overrides">overrides</a>, <a href="#sqlc_package-package">package</a>, <a href="#sqlc_package-queries">queries</a>, <a href="#sqlc_package-schema">schema</a>)
+</pre>
+
+
+sqlc generates **fully type-safe idiomatic Go code** from SQL.
+
+Example:
+```
+    sqlc_package(
+        name = "database",
+        queries = "query.sql",
+        schema = "schema.sql",
+    )
+```
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| emit_empty_slices |  If true, slices returned by :many queries will be empty instead of nil   | Boolean | optional | False |
+| emit_exact_table_names |  If true, struct names will mirror table names. Otherwise, sqlc attempts to singularize plural table names   | Boolean | optional | False |
+| emit_interface |  If true, output a Querier interface in the generated package   | Boolean | optional | False |
+| emit_json_tags |  If true, add JSON tags to generated structs   | Boolean | optional | False |
+| emit_prepared_queries |  If true, include support for prepared queries   | Boolean | optional | False |
+| engine |  Either postgresql or mysql. MySQL support is experimental   | String | optional | "postgresql" |
+| overrides |  A dictionary of type overrides mapping from type to package (e.g. "uuid":"github.com/gofrs/uuid.UUID" or "uuid:nullable":"github.com/gofrs/uuid.UUID" if nullable)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| package |  Use this for the package name rather than the rule name.   | String | optional | "" |
+| queries |  Source SQL query files to compile for this library   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| schema |  Source SQL migration files to compile for this library   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+
+

--- a/sqlc/BUILD.bazel
+++ b/sqlc/BUILD.bazel
@@ -46,7 +46,8 @@ bzl_library(
     deps = [
         "//sqlc/private:providers",
         "//sqlc/private:sqlc_toolchain",
-        "//sqlc/private/rules:library",
+        "//sqlc/private/rules:package",
+        "//sqlc/private/rules:release",
     ],
 )
 

--- a/sqlc/private/BUILD.bazel
+++ b/sqlc/private/BUILD.bazel
@@ -44,6 +44,17 @@ bzl_library(
 )
 
 bzl_library(
+    name = "actions",
+    srcs = [
+        "actions.bzl",
+    ],
+    visibility = ["//sqlc:__subpackages__"],
+    deps = [
+        "@bazel_skylib//lib:versions.bzl",
+    ],
+)
+
+bzl_library(
     name = "providers",
     srcs = [
         "providers.bzl",
@@ -55,8 +66,12 @@ bzl_library(
     name = "sqlc_toolchain",
     srcs = [
         "sqlc_toolchain.bzl",
+        "//sqlc/private/rules_go/lib:platforms",
     ],
     visibility = ["//sqlc:__subpackages__"],
+    deps = [
+        "//sqlc/private:providers.bzl",
+    ],
 )
 
 bzl_library(

--- a/sqlc/private/rules/package.bzl
+++ b/sqlc/private/rules/package.bzl
@@ -92,7 +92,7 @@ sqlc_package = rule(
         ),
         "engine": attr.string(
             default = "postgresql",
-            doc = "Either postgresql or mysql. Defaults to postgresql. MySQL support is experimental",
+            doc = "Either postgresql or mysql. MySQL support is experimental",
             values = ["postgresql", "mysql", "mysql:beta", "_lemon", "_dolphin", "_elephant"],
         ),
         "overrides": attr.string_dict(
@@ -100,26 +100,37 @@ sqlc_package = rule(
         ),
         "emit_json_tags": attr.bool(
             default = False,
-            doc = "If true, add JSON tags to generated structs. Defaults to false.",
+            doc = "If true, add JSON tags to generated structs",
         ),
         "emit_prepared_queries": attr.bool(
             default = False,
-            doc = "If true, include support for prepared queries. Defaults to false.",
+            doc = "If true, include support for prepared queries",
         ),
         "emit_interface": attr.bool(
             default = False,
-            doc = "If true, output a Querier interface in the generated package. Defaults to false.",
+            doc = "If true, output a Querier interface in the generated package",
         ),
         "emit_exact_table_names": attr.bool(
             default = False,
-            doc = "If true, struct names will mirror table names. Otherwise, sqlc attempts to singularize plural table names. Defaults to false.",
+            doc = "If true, struct names will mirror table names. Otherwise, sqlc attempts to singularize plural table names",
         ),
         "emit_empty_slices": attr.bool(
             default = False,
-            doc = "If true, slices returned by :many queries will be empty instead of nil. Defaults to false.",
+            doc = "If true, slices returned by :many queries will be empty instead of nil",
         ),
     },
-    doc = "Generates Go source files for database package from provided SQL code",
+    doc = """
+sqlc generates **fully type-safe idiomatic Go code** from SQL.
+
+Example:
+```
+    sqlc_package(
+        name = "database",
+        queries = "query.sql",
+        schema = "schema.sql",
+    )
+```
+""",
     executable = False,
     output_to_genfiles = True,
     toolchains = ["@plezentek_bazel_sqlc//sqlc:toolchain"],

--- a/sqlc/private/sqlc_toolchain.bzl
+++ b/sqlc/private/sqlc_toolchain.bzl
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@plezentek_bazel_sqlc//sqlc/private:providers.bzl",
+    "//sqlc/private:providers.bzl",
     "SQLCRelease",
 )
 load(
-    "@plezentek_bazel_sqlc//sqlc/private/rules_go/lib:platforms.bzl",
+    "//sqlc/private/rules_go/lib:platforms.bzl",
     "PLATFORMS",
 )
 


### PR DESCRIPTION
Fixes #2 
This updates the main README.md, and adds stardoc generated documentation for the sql_package rule.