### PR TITLE
Change names to reflect bazel rules standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ them available in your Bazel repository.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "plezentek_bazel_sqlc",
+    name = "com_plezentek_rules_sqlc",
     sha256 = "<PLACEHOLDER>",
     urls = [
         "https://github.com/plezentek/bazek-sqlc/releases/download/v1.0.0/bazel-sqlc-v1.0.0.tar.gz"
     ],
 )
 
-load("@plezentek_bazel_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
+load("@com_plezentek_rules_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
 
 sqlc_rules_dependencies()
 
@@ -44,12 +44,12 @@ with `git_repository`
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "plezentek_bazel_sqlc",
+    name = "com_plezentek_rules_sqlc",
     branch = "initial_version",
     remote = "https://github.com/dmayle/bazel-sqlc",
 )
 
-load("@plezentek_bazel_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
+load("@com_plezentek_rules_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
 
 sqlc_rules_dependencies()
 
@@ -61,7 +61,7 @@ In order to generate a Go package called `database`, use the following
 `sql_package` rule.
 
 ```Starlark
-load("@plezentek_bazel_sqlc//sqlc:def.bzl", "sqlc_package")
+load("@com_plezentek_rules_sqlc//sqlc:def.bzl", "sqlc_package")
 
 sqlc_package(
     name = "product_database",
@@ -76,7 +76,7 @@ order to compile a Go library. Notice how the `package` and the `importpath`
 coincide.
 
 ```Starlark
-load("@plezentek_bazel_sqlc//sqlc:def.bzl", "sqlc_package")
+load("@com_plezentek_rules_sqlc//sqlc:def.bzl", "sqlc_package")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 sqlc_package(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,13 +23,13 @@
 # may use to import it (via an http_archive rule or something similar).
 # It's also the name used in labels that refer to this workspace
 # (for example @rules_go_simple//:deps.bzl).
-workspace(name = "plezentek_bazel_sqlc")
+workspace(name = "com_plezentek_rules_sqlc")
 
-load("@plezentek_bazel_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
+load("@com_plezentek_rules_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# sqlc_rules_dependencies declares the dependencies of plezentek_bazel_sqlc.
-# Any project that depends on plezentek_bazel_sqlc should call this.
+# sqlc_rules_dependencies declares the dependencies of com_plezentek_rules_sqlc.
+# Any project that depends on com_plezentek_rules_sqlc should call this.
 sqlc_rules_dependencies()
 
 sqlc_register_toolchains()

--- a/sqlc/private/BUILD.sqlc.bazel
+++ b/sqlc/private/BUILD.sqlc.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@plezentek_bazel_sqlc//sqlc:def.bzl", "declare_toolchains", "sqlc_release")
+load("@com_plezentek_rules_sqlc//sqlc:def.bzl", "declare_toolchains", "sqlc_release")
 
 filegroup(
     name = "sqlc_command",

--- a/sqlc/private/actions.bzl
+++ b/sqlc/private/actions.bzl
@@ -25,7 +25,7 @@ def sqlc_configure(ctx, params, queries, schemas, out, config_path_depth):
 
     # We check the version of the toolchain we're using so that we support the
     # proper features.
-    toolchain = ctx.toolchains["@plezentek_bazel_sqlc//sqlc:toolchain"]
+    toolchain = ctx.toolchains["@com_plezentek_rules_sqlc//sqlc:toolchain"]
     toolchain_version = toolchain.release.version
 
     # Here we convert our overrides attribute to something that sqlc can
@@ -104,7 +104,7 @@ def sqlc_configure(ctx, params, queries, schemas, out, config_path_depth):
 def sqlc_compile(ctx, config_file, config_path_depth, srcs, out):
     """Compile a database library from SQLC config and sources"""
 
-    toolchain = ctx.toolchains["@plezentek_bazel_sqlc//sqlc:toolchain"]
+    toolchain = ctx.toolchains["@com_plezentek_rules_sqlc//sqlc:toolchain"]
 
     # The following hackery is because our toolchain executable needs to be run
     # from the same directory as the config file, which means we need to do

--- a/sqlc/private/release.bzl
+++ b/sqlc/private/release.bzl
@@ -17,7 +17,7 @@ load(
     "generate_toolchain_names",
 )
 load(
-    "@plezentek_bazel_sqlc//sqlc/private/skylib/lib:versions.bzl",
+    "@com_plezentek_rules_sqlc//sqlc/private/skylib/lib:versions.bzl",
     "versions",
 )
 load(
@@ -112,7 +112,7 @@ def _sqlc_download_release_impl(ctx):
     ctx.file("ROOT")
     ctx.template(
         "BUILD.bazel",
-        Label("@plezentek_bazel_sqlc//sqlc/private:BUILD.sqlc.bazel"),
+        Label("@com_plezentek_rules_sqlc//sqlc/private:BUILD.sqlc.bazel"),
         executable = False,
         substitutions = {
             "{goos}": goos,

--- a/sqlc/private/rules/BUILD.bazel
+++ b/sqlc/private/rules/BUILD.bazel
@@ -32,7 +32,7 @@ bzl_library(
     srcs = ["release.bzl"],
     visibility = ["//sqlc:__subpackages__"],
     deps = [
-        "@plezentek_bazel_sqlc//sqlc/private:providers",
+        "@com_plezentek_rules_sqlc//sqlc/private:providers",
     ],
 )
 
@@ -43,6 +43,6 @@ bzl_library(
     ],
     visibility = ["//sqlc:__subpackages__"],
     deps = [
-        "@plezentek_bazel_sqlc//sqlc/private:actions",
+        "@com_plezentek_rules_sqlc//sqlc/private:actions",
     ],
 )

--- a/sqlc/private/rules/package.bzl
+++ b/sqlc/private/rules/package.bzl
@@ -133,5 +133,5 @@ Example:
 """,
     executable = False,
     output_to_genfiles = True,
-    toolchains = ["@plezentek_bazel_sqlc//sqlc:toolchain"],
+    toolchains = ["@com_plezentek_rules_sqlc//sqlc:toolchain"],
 )

--- a/sqlc/private/rules_go/lib/platforms.bzl
+++ b/sqlc/private/rules_go/lib/platforms.bzl
@@ -135,7 +135,7 @@ CGO_GOOS_GOARCH = {
 
 def _generate_constraints(names, bazel_constraints):
     return {
-        name: bazel_constraints.get(name, "@plezentek_bazel_sqlc//sqlc/toolchain:" + name)
+        name: bazel_constraints.get(name, "@com_plezentek_rules_sqlc//sqlc/toolchain:" + name)
         for name in names
     }
 
@@ -153,7 +153,7 @@ def _generate_platforms():
             name = goos + "_" + goarch,
             goos = goos,
             goarch = goarch,
-            constraints = constraints + ["@plezentek_bazel_sqlc//sqlc/toolchain:cgo_off"],
+            constraints = constraints + ["@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_off"],
             cgo = False,
         ))
         if (goos, goarch) in CGO_GOOS_GOARCH:
@@ -164,7 +164,7 @@ def _generate_platforms():
                 name = goos + "_" + goarch + "_cgo",
                 goos = goos,
                 goarch = goarch,
-                constraints = constraints + ["@plezentek_bazel_sqlc//sqlc/toolchain:cgo_on"] + mingw,
+                constraints = constraints + ["@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_on"] + mingw,
                 cgo = True,
             ))
 
@@ -177,14 +177,14 @@ def _generate_platforms():
             name = "ios_" + goarch,
             goos = "darwin",
             goarch = goarch,
-            constraints = constraints + ["@plezentek_bazel_sqlc//sqlc/toolchain:cgo_off"],
+            constraints = constraints + ["@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_off"],
             cgo = False,
         ))
         platforms.append(struct(
             name = "ios_" + goarch + "_cgo",
             goos = "darwin",
             goarch = goarch,
-            constraints = constraints + ["@plezentek_bazel_sqlc//sqlc/toolchain:cgo_on"],
+            constraints = constraints + ["@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_on"],
             cgo = True,
         ))
 

--- a/sqlc/private/rules_go/lib/toolchains.bzl
+++ b/sqlc/private/rules_go/lib/toolchains.bzl
@@ -35,7 +35,7 @@ def declare_constraints():
     @bazel_tools//platforms:default_platform will be used most of the time).
     """
     for goos, constraint in GOOS_CONSTRAINTS.items():
-        if constraint.startswith("@plezentek_bazel_sqlc//sqlc/toolchain:"):
+        if constraint.startswith("@com_plezentek_rules_sqlc//sqlc/toolchain:"):
             native.constraint_value(
                 name = goos,
                 constraint_setting = "@platforms//os:os",
@@ -47,7 +47,7 @@ def declare_constraints():
             )
 
     for goarch, constraint in GOARCH_CONSTRAINTS.items():
-        if constraint.startswith("@plezentek_bazel_sqlc//sqlc/toolchain:"):
+        if constraint.startswith("@com_plezentek_rules_sqlc//sqlc/toolchain:"):
             native.constraint_value(
                 name = goarch,
                 constraint_setting = "@platforms//cpu:cpu",

--- a/sqlc/private/sqlc_toolchain.bzl
+++ b/sqlc/private/sqlc_toolchain.bzl
@@ -63,8 +63,8 @@ def declare_toolchains(host, release):
         impl_name = toolchain_name + "-impl"
 
         cgo_constraints = (
-            "@plezentek_bazel_sqlc//sqlc/toolchain:cgo_off",
-            "@plezentek_bazel_sqlc//sqlc/toolchain:cgo_on",
+            "@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_off",
+            "@com_plezentek_rules_sqlc//sqlc/toolchain:cgo_on",
         )
         constraints = [c for c in p.constraints if c not in cgo_constraints]
 
@@ -78,10 +78,10 @@ def declare_toolchains(host, release):
         )
         native.toolchain(
             name = toolchain_name,
-            toolchain_type = "@plezentek_bazel_sqlc//sqlc:toolchain",
+            toolchain_type = "@com_plezentek_rules_sqlc//sqlc:toolchain",
             exec_compatible_with = [
-                "@plezentek_bazel_sqlc//sqlc/toolchain:" + host_goos,
-                "@plezentek_bazel_sqlc//sqlc/toolchain:" + host_goarch,
+                "@com_plezentek_rules_sqlc//sqlc/toolchain:" + host_goos,
+                "@com_plezentek_rules_sqlc//sqlc/toolchain:" + host_goarch,
             ],
             target_compatible_with = constraints,
             toolchain = ":" + impl_name,

--- a/sqlc/toolchain/BUILD.bazel
+++ b/sqlc/toolchain/BUILD.bazel
@@ -39,6 +39,6 @@ bzl_library(
         "//sqlc/private/rules_go/lib:platforms",
     ],
     deps = [
-        "@plezentek_bazel_sqlc//sqlc/private:release",
+        "@com_plezentek_rules_sqlc//sqlc/private:release",
     ],
 )

--- a/sqlc/toolchain/toolchains.bzl
+++ b/sqlc/toolchain/toolchains.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@plezentek_bazel_sqlc//sqlc/private/rules_go/lib:toolchains.bzl",
+    "@com_plezentek_rules_sqlc//sqlc/private/rules_go/lib:toolchains.bzl",
     _declare_constraints = "declare_constraints",
 )
 


### PR DESCRIPTION
This change is meant to bring the repository into line with the bazel rule standards published at:
https://docs.bazel.build/versions/master/skylark/deploying.html