### PR TITLE
update sqlc releases to 1.16.0 with darwin arm64 support

### DIFF
--- a/sqlc/private/release.bzl
+++ b/sqlc/private/release.bzl
@@ -47,7 +47,7 @@ def _detect_host_platform(ctx):
         uname = arch_result.stdout.strip()
         if uname in ("aarch64", "arm64"):
             goarch = "arm64"
-        if uname in ("armv6l", "armv7l"):
+        elif uname in ("armv6l", "armv7l"):
             goarch = "arm"
         elif uname in ("amd64", "x86_64"):
             goarch = "amd64"

--- a/sqlc/private/sqlc_versions.bzl
+++ b/sqlc/private/sqlc_versions.bzl
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_VERSION = "1.14.0"
+DEFAULT_VERSION = "1.16.0"
 
 MIN_SUPPORTED_VERSION = "1.3.0"
 
 SQLC_VERSIONS = {
+    "1.16.0": {
+        "darwin_amd64": ("sqlc_1.16.0_darwin_amd64.tar.gz", "5c2e55ece21329205187ab71e84f30cbbb547229fe5c4488ec267ed0b189ff0f"),
+        "darwin_arm64": ("sqlc_1.16.0_darwin_arm64.tar.gz", "7d3673422bfde1f10f1138255a20a77a33617f9922c9cc9188fee3a827b0a105"),
+        "linux_amd64": ("sqlc_1.16.0_linux_amd64.tar.gz", "528af084691693527e8fb374890240b9b40490430e1db781308e057cc803e127"),
+    },
+    "1.15.0": {
+        "darwin_amd64": ("sqlc_1.15.0_darwin_amd64.tar.gz", "f6161d3a904d6cc3811cb0c43b821b62860120dd6448b14f9cf2c04b7b5d5c8d"),
+        "linux_amd64": ("sqlc_1.15.0_linux_amd64.tar.gz", "20c3382ca6e56519aee85bdd2f774153fcd0811d1f35560ee6c9379ab89cc52c"),
+    },
     "1.14.0": {
         "darwin_amd64": ("sqlc_1.14.0_darwin_amd64.tar.gz", "142edd3a92716432ee5b5dd48719e2192530c6b29812b36269fc30f51c41fefb"),
         "linux_amd64": ("sqlc_1.14.0_linux_amd64.tar.gz", "80f97a263903bc2376fb2af94ed65ea9846c02863c2da43520fcc4bc13cee849"),


### PR DESCRIPTION
I've tested this and it is working well on my m1 macbook pro!

anyone interested in using this can pull my fork while we wait for the merge + release on this project. you can use the following:
```
load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
git_repository(
    name = "com_plezentek_rules_sqlc",
    branch = "mw-arm",
    remote = "https://github.com/therealwardo/rules_sqlc.git",
)

load("@com_plezentek_rules_sqlc//sqlc:deps.bzl", "sqlc_register_toolchains", "sqlc_rules_dependencies")
sqlc_rules_dependencies()
sqlc_register_toolchains()
```